### PR TITLE
replace iteritems() with items() for a better py3 compatibility

### DIFF
--- a/pyreqif/pyreqif.py
+++ b/pyreqif/pyreqif.py
@@ -569,12 +569,12 @@ class doc(reqIfObject):
         if len(self._specificationList) == 0:
             def createFlatSpec(asd, spec):
                 spec.addReq(asd["reqifId"])
-                for id, child in asd["children"].iteritems():
+                for id, child in asd["children"].items():
                     createFlatSpec(child, spec)
 
             hierarchSpec = self.asHierarchDict()
             spec = specification()
-            for id, topElement in hierarchSpec[0].iteritems():
+            for id, topElement in hierarchSpec[0].items():
                 createFlatSpec(topElement, spec)
             self.addSpecification(spec)
         return self._specificationList
@@ -672,7 +672,7 @@ class doc(reqIfObject):
         tempReq = collections.OrderedDict()
         for col in cols:
             tempReq[col] = ""
-        for col, value in self.flatReq(reqObj, html=True).iteritems():
+        for col, value in self.flatReq(reqObj, html=True).items():
             tempReq[col] = value
             tempReq["reqifId"] = req
         return tempReq

--- a/pyreqif/reqif.py
+++ b/pyreqif/reqif.py
@@ -300,7 +300,7 @@ def dump(doc, f):
     specsRelXml = createSubElement(reqIfContent, "SPEC-RELATIONS")
     for relation in doc.relations:
         specsRel = createSubElement(specsRelXml  , "SPEC-RELATION", attributes=py2reqif(relation))
-        for value,label in py2reqif(relation).iteritems():
+        for value,label in py2reqif(relation).items():
             if value == "typeRef":
                 typeXml = createSubElement(specsRel , "TYPE")
                 createSubElement(typeXml , "SPEC-RELATION-TYPE-REF", label)

--- a/pyreqif/rif.py
+++ b/pyreqif/rif.py
@@ -15,7 +15,7 @@ from pprint import pprint
 import re
 
 def pretty(d, indent=0):
-    for key, value in d.iteritems():
+    for key, value in d.items():
         print ('\t' * indent + str(key))
         if isinstance(value, dict):
             pretty(value, indent+1)
@@ -283,6 +283,8 @@ def load(f):
 
     specObjectsXmlElement = contentRoot.find('./' + ns + 'SPEC-OBJECTS')
     for requirementXml in specObjectsXmlElement:
+        requirement=None
+
         if requirementXml.tag == ns + "SPEC-OBJECT":
             requirement = getSubElementValuesByTitle(requirementXml)
             
@@ -336,7 +338,9 @@ def load(f):
         else:
             print ("Unknown spec object tag:",)
             print (requirementXml.tag)
-        doc.addRequirement(reqif2py(requirement))
+
+        if requirement != None:   
+            doc.addRequirement(reqif2py(requirement))
 
 
     specGroupsXml = contentRoot.find('./' + ns + 'SPEC-GROUPS')
@@ -470,10 +474,10 @@ def dump(doc, f):
             del myDict["TYPE"]
             createSubElements(datatypeXml, myDict)
             specifiedValuesXml = createSubElement(datatypeXml, "SPECIFIED-VALUES")
-            for value,label in datatype.valueTable.iteritems():
+            for value,label in datatype.valueTable.items():
                 valuesXml = createSubElement(specifiedValuesXml , "ENUM-VALUE", attributes=py2reqif(label) )
                 #createSubElement(valuesXml, "IDENTIFIER", value)
-                for element,content in py2reqif(label).iteritems():
+                for element,content in py2reqif(label).items():
                     if element == "properites":
                         props = createSubElement(valuesXml, "PROPERTIES")
                         createSubElement(props, "EMBEDDED-VALUE", attributes=py2reqif(content))
@@ -492,13 +496,13 @@ def dump(doc, f):
         if len(reqType.myTypes) > 0:
             attributesXml = createSubElement(specType,"SPEC-ATTRIBUTES")
 
-            for mytype,ref in reqType.myTypes.iteritems():
+            for mytype,ref in reqType.myTypes.items():
                 attribDict = py2reqif(ref.toDict())
                 if "TYPE" in attribDict and attribDict["TYPE"] == "enum":
                     attribDict.pop("TYPE")
                     attribDict["MULTI-VALUED"] = "false"
                     enumXml = createSubElement(attributesXml,"ATTRIBUTE-DEFINITION-ENUMERATION", attributes=attribDict)
-                    for value,label in attribDict.iteritems():
+                    for value,label in attribDict.items():
                         if value == "typeRef":
                             typeXml = createSubElement(enumXml,"TYPE")
                             createSubElement(typeXml,"DATATYPE-DEFINITION-ENUMERATION-REF",label)
@@ -510,7 +514,7 @@ def dump(doc, f):
 #                    attribDict.pop("TYPE")
                     enumXml = createSubElement(attributesXml,"ATTRIBUTE-DEFINITION-XHTML", attributes=attribDict)
                     attribDict.pop("TYPE")
-                    for value,label in attribDict.iteritems():
+                    for value,label in attribDict.items():
                         if value == "typeRef":
                             typeXml = createSubElement(enumXml,"TYPE")
                             createSubElement(typeXml,"DATATYPE-DEFINITION-XHTML-REF",label)
@@ -521,7 +525,7 @@ def dump(doc, f):
 #                    attribDict.pop("TYPE")
                     enumXml = createSubElement(attributesXml,"ATTRIBUTE-DEFINITION-STRING", attributes=attribDict)
                     attribDict.pop("TYPE")
-                    for value,label in attribDict.iteritems():
+                    for value,label in attribDict.items():
                         if value == "typeRef":
                             typeXml = createSubElement(enumXml,"TYPE")
                             createSubElement(typeXml,"DATATYPE-DEFINITION-STRING-REF",label)
@@ -536,7 +540,7 @@ def dump(doc, f):
     for req in doc.requirementList:
         specXml = createSubElement(specsXml , "SPEC-OBJECT", attributes=py2reqif(req.toDict()))
         requirementDict = py2reqif(req.toDict())
-        for value,label in requirementDict.iteritems():
+        for value,label in requirementDict.items():
             if value == "VALUES":
                 valuesXml = createSubElement(specXml, "VALUES")
                 for value in label:
@@ -554,7 +558,7 @@ def dump(doc, f):
                     else:
                         valueXml = createSubElement(valuesXml, "ATTRIBUTE-VALUE-XHTML", attributes=tempDict)
                         valuesDefinitionsXml = createSubElement(valueXml, "DEFINITION")
-                    for val,lab in py2reqif(value.toDict()).iteritems():
+                    for val,lab in py2reqif(value.toDict()).items():
                         if val == "contentRef" and lab is not None:
                             createSubElement(valuesValuesXml, "ENUM-VALUE-REF",lab)
                         elif val == "attributeRef":
@@ -595,7 +599,7 @@ def dump(doc, f):
     specsRelXml = createSubElement(reqIfContent, "SPEC-RELATIONS")
     for relation in doc.relations:
         specsRel = createSubElement(specsRelXml  , "SPEC-RELATION")
-        for value,label in py2reqif(relation).iteritems():
+        for value,label in py2reqif(relation).items():
             if value == "typeRef":
                 typeXml = createSubElement(specsRel , "TYPE")
                 createSubElement(typeXml , "SPEC-TYPE-REF", label)
@@ -627,7 +631,7 @@ def dump(doc, f):
     def createChildHirachy(parentXmlTag, childObject):
         childrenXml = createSubElement(parentXmlTag, "CHILDREN")
         hierarchXml = createSubElement(childrenXml, "SPEC-HIERARCHY", attributes=py2reqif(childObject.toDict()))
-        for value,label in py2reqif(childObject.toDict()).iteritems():
+        for value,label in py2reqif(childObject.toDict()).items():
             if value == "objectRef":
                 objectXml = createSubElement(hierarchXml , "OBJECT")
                 createSubElement(objectXml, "SPEC-OBJECT-REF", label)
@@ -643,7 +647,7 @@ def dump(doc, f):
     #SPEC-HIERARCHY-ROOT
     for hierarch in doc.hierarchy:
         specHierarchRootXml = createSubElement(specHierarchRootsXml, "SPECIFICATION", attributes=py2reqif(hierarch.toDict()))
-        for value,label in py2reqif(hierarch.toDict()).iteritems():
+        for value,label in py2reqif(hierarch.toDict()).items():
             if value == "typeRef":
                 typeXml = createSubElement(specHierarchRootXml, "TYPE")
                 createSubElement(typeXml, "SPECIFICATION-TYPE-REF", label)


### PR DESCRIPTION
I needed to merge this commit from a fork in order to make things work fine, so I thought it would be a good idea to include this.

- makes pyreqif more robust against empty reqif documents