### PR TITLE
Remove trailing commas in pyreqif.py

### DIFF
--- a/src/pyreqif/pyreqif.py
+++ b/src/pyreqif/pyreqif.py
@@ -667,7 +667,9 @@ class doc(reqIfObject):
                 reqDict[valueType._longname] = ""
                 for contentref in value._contentref:
                     if "longName" in dataType._valueTable[contentref]:
-                        reqDict[valueType._longname] += dataType._valueTable[contentref]["longName"] + ","
+                        reqDict[valueType._longname] += dataType._valueTable[contentref]["longName"] + ", "
+                # remove trailing comma
+                reqDict[valueType._longname] = reqDict[valueType._longname][:-2]        
             else:
                 reqDict[valueType._longname] = value._content
         return reqDict


### PR DESCRIPTION
I think it is better if value strings are joint using ", " and also the comma at the end should be removed.